### PR TITLE
Update to point to Syracuse.io

### DIFF
--- a/slack.md
+++ b/slack.md
@@ -5,31 +5,7 @@ title: Chat Local
 header-img: 'img/slack-action.jpg'
 ---
 
-Come hang out with local Syracuse developers in the OpenHack Syracuse Slack
-group.
+Come hang out with local Syracuse developers in the OpenHack Syracuse Slack.
 
-This is a place to discuss the local development scene, seek help, share advice,
-and discuss everything related to being a Software / Web person in Syracuse NY.
-
-### Get invited!
-
-Enter your email below to get an invite to the group.  
-
-<form method="POST" action="http://slack.openhacksyr.com/invite" id="join-form">
-  <div class="row control-group">
-    <div class="form-group col-xs-12 floating-label-form-group controls">
-      <label>Email Address</label>
-      <input name="email" type="email" class="form-control" placeholder="Email Address" id="email" required data-validation-required-message="Please enter your email address.">
-      <p class="help-block text-danger"></p>
-    </div>
-  </div>
-  <br>
-  <div id="success"></div>
-  <div class="row">
-    <div class="form-group col-xs-12">
-      <button type="submit" class="btn btn-default">Send</button>
-    </div>
-  </div>
-</form>
-
-*No spam, we promise, cancel anytime!*
+You can find us in the `#openhack-meetup` group on the local 
+[Syracuse.io](http://syracuse.io) Slack group.


### PR DESCRIPTION
Since the OpenHack Syracuse slack group has been moved over to syracuse.io, lets update the message on the "chat local" page.
